### PR TITLE
Sort model predictions correctly

### DIFF
--- a/imagenet_utils.py
+++ b/imagenet_utils.py
@@ -42,7 +42,7 @@ def decode_predictions(preds, top=5):
         CLASS_INDEX = json.load(open(fpath))
     results = []
     for pred in preds:
-        top_indices = np.argpartition(pred, -top)[-top:][::-1]
+        top_indices = pred.argsort()[-top:][::-1]
         result = [tuple(CLASS_INDEX[str(i)]) + (pred[i],) for i in top_indices]
         results.append(result)
     return results


### PR DESCRIPTION
The current sorting function does not seem to work properly.

Example:

```
import numpy as np
top = 4
arr = np.array([0, 4, 6, 1, 7])

arr.argsort()[-top:][::-1]
# out: array([4, 2, 1, 3])  correct

np.argpartition(arr, -top)[-top:][::-1]
# out: array([4, 1, 2, 3])   wrong
```
