### PR TITLE
modification for "_obtain_input_shape"

### DIFF
--- a/vgg16.py
+++ b/vgg16.py
@@ -99,7 +99,7 @@ def VGG16(include_top=True, weights='imagenet',
                                       default_size=224,
                                       min_size=48,
                                       data_format=K.image_data_format(),
-                                      include_top=include_top)
+                                      require_flatten=include_top)
 
     if input_tensor is None:
         img_input = Input(shape=input_shape)


### PR DESCRIPTION
For the function "_obtain_input_shape", include_top=include_top does not work in new keras version and had to be changed to require_flatten= include_top.