### PR TITLE
include_top to require_flatten

### DIFF
--- a/inception_v3.py
+++ b/inception_v3.py
@@ -154,7 +154,7 @@ def InceptionV3(include_top=True,
         default_size=299,
         min_size=139,
         data_format=K.image_data_format(),
-        include_top=include_top)
+        require_flatten=include_top)
 
     if input_tensor is None:
         img_input = Input(shape=input_shape)


### PR DESCRIPTION
Function "_obtain_input_shape" in latest keras must have "require_flatten=include_top" instead of "include_top=include_top"